### PR TITLE
Adds single article about load balancers

### DIFF
--- a/flexible-load-balancers-oke.md
+++ b/flexible-load-balancers-oke.md
@@ -1,0 +1,124 @@
+---
+title: Creating flexible OCI Load Balancers with OKE
+parent: tutorials
+tags:
+- kubernetes
+categories: [clouddev]
+date: 2021-11-02 16:17
+description: New load balancer shapes mean more options to optimize your configuration. Ali walks you through how to create these shapes using OKE.
+author: Ali Mukadam
+---
+Until recently, the OCI Load Balancer shapes were fairly restricted to a handful of options:
+
+* 100 Mbps
+* 400 Mbps
+* 8000 Mbps
+
+What’s more, if you had to change the shape, that would involve recreating the load balancer. 
+
+**Not anymore.**
+
+A few more options have been created for new load balancer shapes:
+
+* 10 Mbps-Micro
+* 10 Mbps
+* [Flexible](https://blogs.oracle.com/cloud-infrastructure/post/announcing-oracle-cloud-infrastructure-flexible-load-balancing)
+
+Now, [load balancer](https://blogs.oracle.com/cloud-infrastructure/introducing-dynamic-update-of-load-balancer-shapes) shapes are updatable without having to destroy and recreate them.
+
+So let’s see how we can create them with OKE.
+
+## Creating Load Balancer Shapes
+First, let’s see what load balancer shapes are available in our tenancy.
+
+```sh
+$ oci lb shape list --compartment-id ocid1.compartment.oc1..   
+ "data": [                                                                                                                                                                                   
+    {                                                                                                                                                                                         
+      "name": "100Mbps"                                                                                                                                                                       
+    },                                                                                                                                                                                 
+    {                                                                                                                                                                                         
+      "name": "10Mbps"                                                                                                                                                                        
+    },                                                                                                                                                                                   
+    {                                                                                                                                                                                         
+      "name": "10Mbps-Micro"                                                                                                                                                                  
+    },                                                                                                                                                                                       
+    {                                                                                                                                                                                         
+      "name": "400Mbps"                                                                                                                                                                       
+    },                                                                                                                                                                                        
+    {                                                                                                                                                                                         
+      "name": "8000Mbps"                                                                                                                                                                      
+    } ,                                                                                                                                                                                        
+    {                                                                                                                                                                                         
+      "name": "flexible"                                                                                                                                                                      
+    }                                                                                                                                                                                         
+  ]
+}
+```
+
+As you can see, all the shapes are available. I could use a simple service to have the load balancer created but I want to show that these work equally well with ingress controllers, so let’s use the NGINX Ingress Controller to create one.
+
+### Creating and Updating a Load Blanacer with an Ingress Controller
+Let's first add an ingress controller:
+
+```sh
+$ helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+$ helm repo update
+$ helm install nginx ingress-nginx/ingress-nginx
+```
+By default, this will create a load balancer with a of shape 100 Mbps:
+
+```sh
+$ oci lb load-balancer get --load-balancer-id ocid1.loadbalancer...."shape-name": "100Mbps",...
+```
+
+Let’s say we want to change the shape to 400 Mbps. We can do this with a load balancer annotation and a helm upgrade:
+
+```sh
+$ helm upgrade nginx ingress-nginx/ingress-nginx \
+$ --set controller.service.annotations."service\.beta\.kubernetes\.io/oci-load-balancer-shape"="400Mbps"
+```
+
+If you want to avoid the horrible escapes and `\`, use the `values.yaml` file provided by the chart. All you would need to do is traverse to the annotations section and add the following:
+
+```sh
+$ service.beta.kubernetes.io/oci-load-balancer-shape: "400Mbps"$ 
+```
+
+After the upgrade is done, we can check on the shape again as before. We can see it’s now been upgraded to 400 Mbps:
+
+```sh
+...
+$ "shape-name": "400Mbps",
+...
+```
+
+Now, let’s say we want to create one with the flexible shape and want to take the opportunity to set the bandwidth limits. We can do this passing the following annotations:
+
+When we check on the shape, we see the following:
+
+```sh
+$ helm upgrade nginx ingress-nginx/ingress-nginx --set 
+$ controller.service.annotations."service\.beta\.kubernetes\.io/oci-load-balancer-shape"="flexible" --set 
+```
+
+We can also dynamically change the bandwidth:
+
+```sh
+$ helm upgrade nginx ingress-nginx/ingress-nginx --set controller.service.annotations."service\.beta\.kubernetes\.$ io/oci-load-balancer-shape"="flexible" --set controller.service.annotations."service\.beta\.kubernetes\.io/ 
+$ oci-load-balancer-shape-flex-min"=10 --set controller.service.annotations."service\.beta\.kubernetes\.io/
+$ oci-load-balancer-shape-flex-max"=500      
+$ "shape-name": "flexible",
+```
+
+Now when we check the shape, we can see the changes reflected:
+
+```sh
+$ "shape-details": {                                                                                                                                                                        
+      "maximum-bandwidth-in-mbps": 500,                                                                                                                                                       
+      "minimum-bandwidth-in-mbps": 10                                                                                                                                                         
+    },                                                                                                                                                                                        
+$ "shape-name": "flexible",
+```
+
+Finally, all the OCI Load Balancer annotations can be found [here](https://github.com/oracle/oci-cloud-controller-manager/blob/master/docs/load-balancer-annotations.md). These annotations allow you to control the behaviour of the load balancers created by OKE.

--- a/flexible-load-balancers-oke.md
+++ b/flexible-load-balancers-oke.md
@@ -31,7 +31,7 @@ So let’s see how we can create them with OKE.
 ## Creating Load Balancer Shapes
 First, let’s see what load balancer shapes are available in our tenancy.
 
-```sh
+```console
 $ oci lb shape list --compartment-id ocid1.compartment.oc1..   
  "data": [                                                                                                                                                                                   
     {                                                                                                                                                                                         
@@ -61,33 +61,33 @@ As you can see, all the shapes are available. I could use a simple service to ha
 ### Creating and Updating a Load Blanacer with an Ingress Controller
 Let's first add an ingress controller:
 
-```sh
+```console
 $ helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 $ helm repo update
 $ helm install nginx ingress-nginx/ingress-nginx
 ```
 By default, this will create a load balancer with a of shape 100 Mbps:
 
-```sh
+```console
 $ oci lb load-balancer get --load-balancer-id ocid1.loadbalancer...."shape-name": "100Mbps",...
 ```
 
 Let’s say we want to change the shape to 400 Mbps. We can do this with a load balancer annotation and a helm upgrade:
 
-```sh
+```console
 $ helm upgrade nginx ingress-nginx/ingress-nginx \
 $ --set controller.service.annotations."service\.beta\.kubernetes\.io/oci-load-balancer-shape"="400Mbps"
 ```
 
 If you want to avoid the horrible escapes and `\`, use the `values.yaml` file provided by the chart. All you would need to do is traverse to the annotations section and add the following:
 
-```sh
+```console
 $ service.beta.kubernetes.io/oci-load-balancer-shape: "400Mbps"$ 
 ```
 
 After the upgrade is done, we can check on the shape again as before. We can see it’s now been upgraded to 400 Mbps:
 
-```sh
+```console
 ...
 $ "shape-name": "400Mbps",
 ...
@@ -97,14 +97,14 @@ Now, let’s say we want to create one with the flexible shape and want to take 
 
 When we check on the shape, we see the following:
 
-```sh
+```console
 $ helm upgrade nginx ingress-nginx/ingress-nginx --set 
 $ controller.service.annotations."service\.beta\.kubernetes\.io/oci-load-balancer-shape"="flexible" --set 
 ```
 
 We can also dynamically change the bandwidth:
 
-```sh
+```console
 $ helm upgrade nginx ingress-nginx/ingress-nginx --set controller.service.annotations."service\.beta\.kubernetes\.$ io/oci-load-balancer-shape"="flexible" --set controller.service.annotations."service\.beta\.kubernetes\.io/ 
 $ oci-load-balancer-shape-flex-min"=10 --set controller.service.annotations."service\.beta\.kubernetes\.io/
 $ oci-load-balancer-shape-flex-max"=500      
@@ -113,7 +113,7 @@ $ "shape-name": "flexible",
 
 Now when we check the shape, we can see the changes reflected:
 
-```sh
+```console
 $ "shape-details": {                                                                                                                                                                        
       "maximum-bandwidth-in-mbps": 500,                                                                                                                                                       
       "minimum-bandwidth-in-mbps": 10                                                                                                                                                         


### PR DESCRIPTION
No images here. One code block (ln 92) has ... before and after the line. Checked with the author who said this is meant to indicate that the line is found within a larger block of information. I don’t have an opinion about how we format that now or in the future, so feel free to edit as needed there. 