### PR TITLE
Final tim tut edits

### DIFF
--- a/tf-101/6-changing.md
+++ b/tf-101/6-changing.md
@@ -26,11 +26,11 @@ xredirect: https://developer.oracle.com/tutorials/tf-101/6-changing/
 {% slides %}
 {% imgx aligncenter assets/terraform-101.png 400 400 "Terraform 101" "Terraform 101 Tutorial Series" %}
 
-Most environments tend to change on a regular basis.  These changes can be easily managed in a reliable, scalable way using Terraform.  Let's try this out now.
+Most DevOps environments tend to change on a regular basis. These changes can be easily managed in a reliable, scalable way using Terraform. Let's try this out now.
 
 ## Prerequisites
 
-It's assumed that you're building off of the environment built in the [Creating Resources with Terraform tutorial](5-creating).
+I'm assuming that you're building off of the environment found in the [Creating Resources with Terraform tutorial](5-creating).
 
 ## Managing Change
 
@@ -41,22 +41,24 @@ When managing an environment with Terraform, there are largely three data source
 * Environment As-Built
 
 ### Terraform Code
-The Terraform code is where you tell Terraform what you want it to manage.  As you've already seen, the Terraform code is just plain-text files with a `.tf` extension.
+The Terraform code is where you tell Terraform what you want it to manage. As you've already seen, Terraform code is just a plain-text file with a `.tf` extension.
 
-Many teams find it beneficial to commit their Terraform source code to a version control system (VCS) such as a git repository.  The VCS allows for limiting access to the source code (which can effectively contain your Oracle Cloud Infrastructure (OCI) topology, assuming it's defined in Terraform code).  Another benefit to using a VCS is having a natural audit trail of what has transpired in the environment (who-did-what-and-when).
+Many teams find it beneficial to commit their Terraform source code to a version control system (VCS) such as a git repository. The VCS allows for limiting access to the source code (which can effectively contain your Oracle Cloud Infrastructure (OCI) topology, assuming it's defined in Terraform code). Another benefit to using a VCS is having a natural audit trail of what has transpired in the environment (who did what and when).
 
 ### Terraform State
-The Terraform state is a critical piece of information that Terraform will use upon each execution, cross-referencing what is deployed against the code and against what is cached in the state.  Additional resource data points are stored in the state, such as the OCID for a resource (after it's been created) as well as many other attributes that might not be explicitly set in the Terraform code.
+The Terraform state is a critical piece of information that Terraform will use upon each execution, cross-referencing what is deployed against the code and against what is cached in the state. Additional resource data points are stored in the state, such as the OCID for a resource (after it's been created) as well as other attributes which might not be explicitly set in the Terraform code.
 
-When working as a team, it's important that each team member have a current, up-to-date copy of the Terraform state.  To keep things consistent, only one member of the team should make changes to the environment at any single point in time.
+When working as a team, it's important that each team member have a current, up-to-date copy of the Terraform state. To keep things consistent, only one member of the team should make changes to the environment at any single point in time.
 
-By default, the Terraform state is stored in the `terraform.tfstate` file located in the working directory.  There are several options for managing the Terraform State, but for now we'll be using the [local backend](https://www.terraform.io/docs/language/settings/backends/local.html) (which happens to be the default).
+By default, the Terraform state is stored in the `terraform.tfstate` file located in the working directory. There are several options for managing the Terraform State, but for now we'll be using the [local backend](https://www.terraform.io/docs/language/settings/backends/local.html), which happens to be the default.
 
 ### Environment As-Built
-The actual OCI (or other environment) resources that are present (or missing).  While this isn't really part of the Terraform configuration, managing resources is the reason that Terraform is being used.  Each run, Terraform will check the current as-built state of the environment, comparing it against the Terraform State and the code that is provided, to determine what might need to take place to bring the actual environment configuration into alignment with the desired end-state configuration given in the Terraform code.
+During each run, Terraform will check the current as-built state of the environment, comparing it against the Terraform State and the provided code, to determine what might need to occur to bring the actual environment configuration into alignment with the desired end-state configuration given in the Terraform code.
 
 ## Adding a Resource
-To start, let's add three new Subnets to the Virtual Cloud Network (VCN) that was created in the [previous tutorial](5-creating).  Add the following to your `main.tf` file:
+To start, let's add three new Subnets to the Virtual Cloud Network (VCN) which was created in the [previous tutorial](5-creating). 
+
+Add the following to your `main.tf` file:
 
 ```terraform
 resource "oci_core_subnet" "dev_1" {
@@ -87,12 +89,12 @@ resource "oci_core_subnet" "stage" {
 }
 ```
 
-> **NOTE:** Make sure to use the compartment_id you wish to use.
+> **NOTE:** Make sure to replace my `compartment_id` placeholder with your own.
 {:.notice}
 
-The above code adds three new subnets: one development Subnet, one testing Subnet and, one staging Subnet.  Each of these is placed in the compartment specified, within the VCN that was created in the [previous tutorial](5-creating).  Each has a unique IPv4 CIDR block which falls within the broader VCN IPv4 CIDR block.  None of the subnets permits public IPs to be used (they're prohibited).
+The above code adds three new subnets: one development subnet, one testing subnet and, one staging subnet. Each of these is placed in the specified compartment within the VCN that was created in the [previous tutorial](5-creating). Each subnet has a unique IPv4 CIDR block which falls within the broader VCN IPv4 CIDR block. None of the subnets permit public IPs to be used (they're prohibited).
 
-Confirm that this will do what is intended by examining the Terraform plan:
+Confirm that this will work as intended by examining the Terraform plan:
 
 ```console
 $ terraform plan
@@ -188,9 +190,9 @@ can't guarantee that exactly these actions will be performed if
 "terraform apply" is subsequently run.
 ```
 
-The plus sign (+) next to the three subnets listed in the above output means that Terraform is going to add three Subnet resources to your environment.  The existing VCN resource will remain unchanged. 
+The plus sign **(+)** next to the three subnets listed in the above output means that Terraform is going to add three subnet resources to your environment. The existing VCN resource will remain unchanged. 
 
-Being satisfied with this plan, apply it (to implement it).
+Being satisfied with this plan, implement it using the `apply` command:
 
 ```console
 $ terraform apply
@@ -296,13 +298,13 @@ oci_core_subnet.dev_1: Creation complete after 12s [id=ocid1.subnet.oc1.phx.<san
 Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
 ```
 
-Voila!  Your VCN now has three subnets in it.  This was a really easy way to add OCI resources to the VCN: add to the Terraform code in `main.tf` and ask Terraform to apply it!
+Voila! Your VCN now has three subnets in it. This was a really easy way to add OCI resources to the VCN: just add to the Terraform code in `main.tf` and ask Terraform to apply it!
 
 ## Modifying a Resource
 
-As your fictitious environment is coming together, it's realized that the name of the development subnet isn't ideal.  Rather than calling it `dev_1`, this should be changed to just `dev`.
+As your fictitious environment is coming together, you realize that the name of the development subnet isn't ideal. Rather than calling it `dev_1`, let's say you want to rename it to just `dev`.
 
-Because Terraform uses Infrastructure-as-Code (IaC), this can be done with a few minor changes to the `main.tf` file and then ask Terraform to apply it.  It's that easy!
+Because Terraform uses Infrastructure-as-Code (IaC), this can be done with a few minor changes to the `main.tf` file, after which you just tell Terraform to apply it. It's that easy!
 
 Modify the existing the `oci_core_subnet.dev_1` resource definition in your `main.tf` to match the following:
 
@@ -406,20 +408,22 @@ can't guarantee that exactly these actions will be performed if
 "terraform apply" is subsequently run.
 ```
 
-Oh, no --- it looks like something has gone terribly awry! Terraform wants to destroy the `dev_1` Subnet and create a new `dev` subnet.
+Oh no - it looks like something has gone terribly awry! Terraform wants to destroy the `dev_1` subnet and create a new `dev` subnet.
+
+Let's find out why.
 
 ### Why is a Resource Being Deleted-and-Re-Created?
 
 There are two primary reasons why a resource might be destroyed and re-created:
 
-*	Platform (cloud) constraints
-*	Renaming a resource name
+*	platform (cloud) constraints
+*	renaming a resource name
 
-In OCI, many changes are non-disruptive, however there are some resource changes that might be disruptive.  Take for instance the dns_label attribute.  According to the [OCI provider documentation for the Subnet resource](https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_subnet#dns_label), the dns_label cannot be changed.  This would mean that if you wanted to change it on an existing OCI Subnet, you could see this delete-and-re-create behavior.  Terraform is smart enough to know that if an attribute cannot be updated in-place, then it must delete and re-create the resource.
+In OCI, many changes are non-disruptive. However, there are some resource changes that might be disruptive. Take for instance the `dns_label` attribute. According to the [OCI provider documentation for the Subnet resource](https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_subnet#dns_label), the `dns_label` cannot be changed. This would mean that if you wanted to change it on an existing OCI Subnet, you could see this delete-and-re-create behavior. Terraform is smart enough to know that if an attribute cannot be updated in-place, then it must delete and re-create the resource.
 
-The second situation occurs when you totally change the name of a resource in the Terraform code and don't ask Terraform to update the Terraform state.  From Terraform's perspective, it looks like you want to delete the old resource (which is present in the Terraform state, but does not exist in the code) and create a net-new resource (because your code refers to a resource that's non-existent in the Terraform state).
+The second situation occurs when you totally change the name of a resource in the Terraform code and don't ask Terraform to update the Terraform state. From Terraform's perspective, it looks like you want to delete the old resource (which is present in the Terraform state, but does not exist in the code) and create a net-new resource (because your code refers to a resource that's non-existent in the Terraform state).
 
-This can be a common mistake and be troublesome, but it can be easily resolved.  Rename the resource name in the Terraform state from the old name to the new name.  Terraform will then move forward as expected.  Do this now with the `terraform state mv` command:
+This can be a common mistake and be troublesome, but it can be easily resolved. Rename the resource name in the Terraform state from the old name to the new name. Terraform will then move forward as expected. Do this now with the `terraform state mv` command:
 
 ```console
 $ terraform state mv oci_core_subnet.dev_1 oci_core_subnet.dev
@@ -427,12 +431,13 @@ Move "oci_core_subnet.dev_1" to "oci_core_subnet.dev"
 Successfully moved 1 object(s).
 ```
 
-The above command asks Terraform to rename (move) the old resource name to a new resource name in the Terraform State.  Take a look at the [Terraform documentation](https://www.terraform.io/docs/cli/commands/state/mv.html) for more information.
+The above command asks Terraform to rename (move) the old resource name to a new resource name in the Terraform State. Take a look at the [Terraform documentation](https://www.terraform.io/docs/cli/commands/state/mv.html) for more information.
 
-> **NOTE:** When referencing resources in Terraform, the type of resource and its name must be used.  This is why in the above command, `oci_core_subnet.dev_1` was used instead of `dev_1`.
-> The same name may be used multiple times, as long as it's used for different types of resources.  For instance, an OCI Route Table called `dev_1` could also exist without problem (referenced as `oci_core_route_table.dev_1`).
+> **NOTE:** When referencing resources in Terraform, both the type of resource and its name must be used. This is why in the above command, `oci_core_subnet.dev_1` is used instead of `dev_1`.
+
+> The same resource name may be used multiple times as long as it's used for different types of resources. For example, an OCI Route Table called `dev_1` could also exist without problem (referenced as `oci_core_route_table.dev_1`).
 > When choosing names for your resources, it's unnecessary (and a bad idea) to include the type of resource in its name, because the resource type will always prefix the name when referencing it.
-> For example, instead of using `oci_core_subnet.subnet_dev_1`, consider using `oci_core_subnet.dev_1`. It's clearly visible that this is referencing a Subnet, however the second version is a lot shorter and easier to read!
+> For example, instead of using `oci_core_subnet.subnet_dev_1`, consider using `oci_core_subnet.dev_1`. It's clear that this is referencing a subnet. However, the second version is a lot shorter and easier to read!
 {:.notice}
 
 Look at the Terraform plan again:
@@ -461,12 +466,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
 
 ------------------------------------------------------------------------
 
-Note: You didn't specify an "-out" parameter to save this plan, so Terraform
+Note: You didn't specify an "-out" parameter to save this plan, so Terraform 
 can't guarantee that exactly these actions will be performed if
 "terraform apply" is subsequently run.
 ```
 
-The tilde (`~`) indicates an in-place change, which is what is expected for the display_name.  Proceed with applying the change:
+The tilde (`~`) indicates an in-place change, which is what is expected for the `display_name`. Proceed with applying the change:
 
 ```console
 $ terraform apply
@@ -496,7 +501,7 @@ oci_core_subnet.dev: Modifications complete after 3s [id=ocid1.subnet.oc1.phx.<s
 Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
 ```
 
-This tutorial took a slight detour, highlighting a scenario where a resource had to be renamed in the Terraform State to achieve the desired outcome.  Your OCI environment now has a VCN with three Subnets in it.
+This tutorial took a slight detour, highlighting a scenario where a resource had to be renamed in the Terraform State to achieve the desired outcome, but now your OCI environment has a VCN with three subnets in it.
 
-We've had fun creating new OCI resources and then making modifications to the environment.  It's now time to clean things up.  We'll explore destroying resources in the [next lesson](7-destroying).
+We've had fun creating new OCI resources and then making modifications to the environment. It's now time to clean things up. We'll explore destroying resources in the [next lesson](7-destroying).
 {% endslides %}

--- a/tf-101/7-destroying.md
+++ b/tf-101/7-destroying.md
@@ -25,11 +25,11 @@ xredirect: https://developer.oracle.com/tutorials/tf-101/7-destroying/
 {% slides %}
 {% imgx aligncenter assets/terraform-101.png 400 400 "Terraform 101" "Terraform 101 Tutorial Series" %}
 
-So far we've had some fun creating and changing OCI resources.  Our tutorial is coming to a close, so it's time to remove the resources we've added and clean-up after ourselves.  Terraform makes this amazingly easy.  Let's explore this now.
+So far, we've had some fun creating and changing OCI resources. Our tutorial is coming to a close though, so it's time to remove the resources we've added and clean-up after ourselves. Terraform makes this amazingly easy. Let's explore this now.
 
 ## Removing a Resource
 
-The `stage` Subnet will be removed.  To do this, remove its resource definition (the following code snippet) from the `main.tf` file:
+To remove the `stage` subnet, we'll first need to remove its resource definition (the following code snippet) from the `main.tf` file:
 
 ```terraform
 resource "oci_core_subnet" "stage" {
@@ -42,7 +42,7 @@ resource "oci_core_subnet" "stage" {
 }
 ```
 
-Look at the Terraform plan to make sure it's correct:
+Look at the Terraform plan to ensure it's correct:
 
 ```console
 $ terraform plan
@@ -51,7 +51,7 @@ oci_core_vcn.tf101: Refreshing state... [id=ocid1.vcn.oc1.phx.<sanitized>]
 oci_core_subnet.test: Refreshing state... [id=ocid1.subnet.oc1.phx.<sanitized>]
 oci_core_subnet.dev: Refreshing state... [id=ocid1.subnet.oc1.phx.<sanitized>]
 
-An execution plan has been generated and is shown below.
+An execution plan has been generated and is shown below. 
 Resource actions are indicated with the following symbols:
   - destroy
 
@@ -89,10 +89,10 @@ can't guarantee that exactly these actions will be performed if
 "terraform apply" is subsequently run.
 ```
 
-> **NOTE:** It might feel redundant to keep looking at the output from `terraform plan` when the same output is given when you run `terraform apply` (before telling it to continue).  It's a good habit to always review proposed changes *before* making them.  By running plan and then apply, it forces you to closely look at what's going to happen to the environment (before it happens), giving you valuable time to stop or change what's going to take place.
+> **NOTE:** It might feel redundant to keep looking at the output from `terraform plan` when the same output is given when you run `terraform apply` (before telling it to continue). It might *feel* redundant, but it's a good habit to always review proposed changes *before* making them. By running the plan and then applying it, you're forcing yourself to closely look at what's going to happen to the environment (before it happens) giving you valuable time to stop or change what's going to take place.
 {:.notice}
 
-The minus sign (`-`) in front of the oci_core_subnet.stage is how Terraform indicates it will be removing the resource from the environment ("terminated" in OCI speak).  Proceed with applying it:
+The minus sign (`-`) in front of the `oci_core_subnet.stage` is how Terraform indicates it will be removing the resource from the environment ("terminated," in OCI speak). Proceed with applying it:
 
 ```console
 $ terraform apply
@@ -113,24 +113,24 @@ oci_core_subnet.stage: Destruction complete after 4s
 Apply complete! Resources: 0 added, 0 changed, 1 destroyed.
 ```
 
-With the `stage` Subnet removed, the environment is a bit cleaner.
+With the `stage` subnet removed, the environment is a bit cleaner.
 
 ### Deleting and Re-creating a Resource
 
-We chose to permanently delete the `stage` Subnet.  In situations where a single resource should be destroyed and then re-created, there are a couple of options (rather than modify the Terraform code):
+We chose to permanently delete the `stage` subnet. In situations where a single resource should be destroyed and then re-created, there are a couple of options (rather than modifying the Terraform code):
 
 * `terraform destroy` command
-* Taint a resource
+* taint a resource
 
-The `terraform destroy -target=type.name` command is handy.  Instead of deleting the stage Subnet in your code and running `terraform apply`, you could have run `terraform destroy -target=oci_core_subnet.stage`.  Of course, if you don't remove (or comment out) the code for the stage Subnet, the next time you run `terraform apply`, it would want to re-create the stage Subnet.
+The `terraform destroy -target=type.name` command is handy. Instead of deleting the stage subnet in your code and running `terraform apply`, you could have run `terraform destroy -target=oci_core_subnet.stage`. Of course, if you don't remove (or comment out) the code for the stage subnet, the next time you run `terraform apply`, it would want to re-create the stage Subnet.
 
-When a resource is "tainted," it will be deleted and re-created.  The command `terraform taint type.name` is how a resource is tainted.  Here's an example of how the staging subnet could've been tainted: `terraform taint oci_core_subnet.stage` (followed by `terraform plan` and `terraform apply`).  The next time Terraform applies, it will delete and re-create the resource.  Look at the [Terraform taint command documentation](https://www.terraform.io/docs/cli/commands/taint.html) for more information.
+When a resource is "tainted," it will be deleted and re-created. The command `terraform taint type.name` is how a resource is tainted. Here's an example of how the staging subnet could've been tainted: `terraform taint oci_core_subnet.stage` (followed by `terraform plan` and `terraform apply`). The next time Terraform applies, it will delete and re-create the resource. Look at the [Terraform taint command documentation](https://www.terraform.io/docs/cli/commands/taint.html) for more information.
 
 ## Removing All Resources
 
-When it's time to fully terminate (destroy) an environment, Terraform has a single command that can accomplish this.
+When it's time to fully terminate (destroy) an environment, Terraform has a single command that accomplishes this.
 
-While this could be accomplished by removing resource definitions from the `main.tf` (Terraform code) file, that isn't ideal.  What if the environment needs to be provisioned in the future?  Keep the Terraform code and use the `terraform destroy` command to clean-up (terminate/destroy) the environment:
+While this could be accomplished by removing resource definitions from the `main.tf` (Terraform code) file, that isn't ideal. What if the environment needs to be provisioned in the future? Keep the Terraform code and use the `terraform destroy` command to clean-up (terminate/destroy) the environment:
 
 ```console
 $ terraform destroy
@@ -225,9 +225,9 @@ oci_core_vcn.tf_101: Destruction complete after 1s
 Destroy complete! Resources: 3 destroyed.
 ```
 
-Much like the apply command, the destroy command alerts you as to what it intends to do, prompting you to authorize it before continuing.
+Much like the `apply` command, the destroy command alerts you as to what it intends to do, prompting you to authorize it before continuing.
 
-Things are now really cleaned up.  The Subnets and VCN is gone.  Speaking of being gone, did you notice how Terraform removed the OCI resources in the order of their dependency?  It didn't try to remove the VCN first (which would've failed because of the presence of the Subnets), but instead destroyed the two Subnets first, then destroyed the VCN.  That's part of the graph logic that Terraform applies to make managing your environment easy.  Pretty slick, right?
+Things are now really cleaned up. The subnets and VCN are gone. Speaking of being gone, did you notice how Terraform removed the OCI resources in the order of their dependency? It didn't try to remove the VCN first (which would've failed because of the presence of the subnets), but instead destroyed the two subnets first, then destroyed the VCN. That's part of the graph logic that Terraform applies to make managing your environment easy. Pretty slick, right?
 
-We've had a great time together, but this tutorial is coming to a close.  Before we part, make sure to check out some of the [resources offered in the next section](8-resources).
+We've had a great time together, but this tutorial is coming to a close. Before we part, make sure to check out some of the [resources offered in the next section](8-resources).
 {% endslides %}

--- a/tf-101/8-resources.md
+++ b/tf-101/8-resources.md
@@ -25,13 +25,13 @@ xredirect: https://developer.oracle.com/tutorials/tf-101/8-resources/
 
 {% imgx aligncenter assets/terraform-101.png 400 400 "Terraform 101" "Terraform 101 Tutorial Series" %}
 
-I hope that you've found this tutorial series helpful and worth your time.  Terraform is powerful and can make managing your cloud environments easy and efficient.  While our time together has been great, we've only had time to scratch the surface!
+I hope that you've found this tutorial series helpful and worth your time. Terraform is powerful and can make managing your cloud environments easy and efficient. While our time together has been great, we've only had time to scratch the surface!
 
-Before parting ways, there are several resources that I've curated with the hope that it'll help expand your skills and experience around using Terraform with OCI.  Without further ado:
+Before parting ways, there are several resources that I've curated with the hope that it'll help expand your skills and experience around using Terraform with OCI. Without further ado:
 
 ## Terraform Modules
 
-We haven't had a chance to talk about modules, but they're a great way to extend and scale Terraform.  Here are a few places to look for OCI Terraform modules:
+We haven't had a chance to talk about modules, but they're a great way to extend and scale Terraform. Here are a few places to look for OCI Terraform modules:
 
 * [HashiCorp Terraform Module Registry](https://registry.terraform.io/browse/modules?provider=oci)
 * [github.com/oracle-devrel](https://github.com/oracle-devrel)
@@ -48,7 +48,7 @@ There are Terraform projects for many common applications just waiting for you t
 
 ## Terraform Documentation
 
-There's a plethora of great documentation on the [terraform.io](https://terraform.io) site.  Be sure to check it out and go through the documentation and learning guides!
+There's a plethora of great documentation on the [terraform.io](https://terraform.io) site. Be sure to check it out and go through the documentation and learning guides!
 
 For OCI-specific documentation, check out:
 


### PR DESCRIPTION
Edits for the tutorials mostly include lower casing "subnets." Tim used both cap'd and lower cased and since subnets are a component of the network like anything else, I'm opting for lower casing.

The resources article is mostly untouched, save editing Tim's double-spacing after sentences. 